### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Warning: 
 
-* this project is still in progress, with a lot of unstable features.
+* This project is still in progress, with a lot of unstable features.
 Please read the tests in `NiLangCore.jl` and `NiLang.jl` to figure out the tested features.
-* requires Julia version >= 1.3
+* Requires Julia version >= 1.3.
 
 
 NiLang.jl (逆lang), is a reversible domain sepecific language (DSL) in Julia.
-It features
+It features:
 
-* An instruction level (i.e. only backward rules of `+`, `-`, `*` and `/` are required) automatic differentiation engine,
-* A reversible language with abstraction and arrays,
-* Arbituary high order gradint (in progress).
+* an instruction level (i.e. only backward rules of `+`, `-`, `*` and `/` are required) automatic differentiation engine,
+* a reversible language with abstraction and arrays,
+* arbituary high order gradint (in progress).
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://GiggleLiu.github.io/NiLang.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://GiggleLiu.github.io/NiLang.jl/dev)
@@ -47,14 +47,14 @@ end
 ```
 
 Notes:
-* `+=` and `-=` are inplace `+` and `-` operations.
-In fact, all instructions/function in `NiLang` are (effectively) inplace.
+* `+=` and `-=` are in-place `+` and `-` operations.
+In fact, all instructions/function in `NiLang` are (effectively) in-place.
 * `@anc x = val` declares an ancilla register with initial value `val`.
-At the end of computation, this ancilla register must be reset to `0` and return to system,
+At the end of the computation, this ancilla register must be reset to `0` and return to system,
 otherwise raises `InvertibilityError`.
-* control flow `for start:step:stop ... end` looks quite similar to traditional computation,
+* Control flow `for start:step:stop ... end` looks quite similar to traditional computation,
 except it errors if `start`, `step` or `stop` changes during computation.
-* `if` and `while` statement is a bit different, they use a tuple of (precondition, postcondition) as input. precondition is used in forward execution, postcondition is used in backward execution.
+* `if` and `while` statements are a bit different, they use a tuple of (precondition, postcondition) as input. Precondition is used in forward execution, postcondition is used in backward execution.
 These two conditions should match, otherwise errors.
 
 2. The autodiff engine


### PR DESCRIPTION
The tagline: "differential DSL that can run fater than light and go back to the past." also has a typo, assuming "faster", but not sure how to fix.

Not sure if hyphen is wanted; also for pre- and post-condition. Auto-diff?

I look forward to looking more into this intriguing package.