### PR TITLE
Remove redundant forward computations in `jacobian_repeat` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,8 +23,8 @@ TupleTools = "1.2"
 julia = "1.3,1.4"
 
 [extras]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/autodiff/jacobian.jl
+++ b/src/autodiff/jacobian.jl
@@ -10,12 +10,11 @@ function jacobian_repeat(f, args...; iin::Int, iout::Int=iin, kwargs...)
     _check_input(args, iin, iout)
     N = length(args[iout])
     res = zeros(eltype(args[iin]), length(args[iin]), N)
+    xargs = NiLangCore.wrap_tuple(f(args...; kwargs...))
     for i = 1:N
-        xargs = _copy.(args)
-        xargs = NiLangCore.wrap_tuple(f(xargs...; kwargs...))
-        xargs = GVar.(xargs)
-        @inbounds xargs[iout][i] = GVar(value(xargs[iout][i]), one(eltype(args[iout])))
-        @inbounds res[:,i] .= vec(grad.(NiLangCore.wrap_tuple((~f)(xargs...; kwargs...))[iin]))
+        gxargs = GVar.(xargs)
+        @inbounds gxargs[iout][i] = GVar(value(gxargs[iout][i]), one(eltype(xargs[iout])))
+        @inbounds res[:,i] .= vec(grad.(NiLangCore.wrap_tuple((~f)(gxargs...; kwargs...))[iin]))
     end
     return res
 end


### PR DESCRIPTION
Details have been discussed [here](https://github.com/GiggleLiu/NiLang.jl/issues/29).