### PR TITLE
add `i_mean` and `i_sum`, tweak `i_mean_sum` performance

### DIFF
--- a/src/stdlib/statistics.jl
+++ b/src/stdlib/statistics.jl
@@ -1,16 +1,78 @@
-export i_mean_sum, i_var_mean_sum, i_normal_logpdf, i_cor_cov
+export i_mean_sum, i_mean, i_sum, i_var_mean_sum, i_normal_logpdf, i_cor_cov
 export VarianceInfo
 
 """
-    i_mean_sum(out!, sum!, x)
+    i_mean_sum(mean_val, sum_val, x)
 
-get the `mean` and `sum` of `x`.
+Get the `mean` and `sum` of `x` in one routine.
+
+```jldoctest; setup=:(using NiLang)
+x = rand(64, 64)
+m, s, x = i_mean_sum(0.0, 0.0, x)
+(m, s) .≈ (mean(x), sum(x))
+
+# output
+(true, true)
+```
+
+See also: [`i_mean`](@ref), [`i_sum`](@ref)
 """
-@i function i_mean_sum(out!, sum!, x)
-    for i=1:length(x)
-        sum! += x[i]
+@i function i_mean_sum(mean_val, sum_val, x)
+    @inbounds @simd for i in eachindex(x)
+        sum_val += x[i]
     end
-    out! += sum!/(@const length(x))
+    mean_val += sum_val/(@const length(x))
+end
+
+"""
+    i_sum(sum_val, x)
+
+Get the `sum` of `x`.
+
+```jldoctest; setup=:(using NiLang)
+x = rand(64, 64)
+i_sum(0.0, x)[1] ≈ sum(x)
+
+# output
+true
+```
+
+!!! tip
+    If you need both `mean` and `sum` of `x`, then you can use a more
+    performant version [`i_mean_sum`](@ref).
+"""
+@i function i_sum(sum_val, x)
+    @inbounds @simd for i in eachindex(x)
+        sum_val += x[i]
+    end
+end
+
+"""
+    i_mean(mean_val, x)
+
+Get the `mean` of `x`.
+
+```jldoctest; setup=:(using NiLang)
+x = rand(64, 64)
+i_mean(0.0, x)[1] ≈ Statistics.mean(x)
+
+# output
+true
+```
+
+!!! tip
+    If you need both `mean` and `sum` of `x`, then you can use a more
+    performant version [`i_mean_sum`](@ref).
+"""
+@i function i_mean(mean_val, x::AbstractArray)
+    @routine begin
+        sum_val ← zero(eltype(x))
+        @inbounds @simd for i in eachindex(x)
+            sum_val += x[i]
+        end
+    end
+    mean_val += sum_val/(@const length(x))
+    ~@routine
 end
 
 struct VarianceInfo{T}

--- a/test/stdlib/statistics.jl
+++ b/test/stdlib/statistics.jl
@@ -6,7 +6,14 @@ using Distributions
 @testset "statistics" begin
     x = randn(100)
     y = randn(100)
-    @test i_mean_sum(0.0, 0.0, x)[1] ≈ Statistics.mean(x)
+
+    @test check_inv(i_mean_sum, (0.0, 0.0, x))
+    @test all(i_mean_sum(0.0, 0.0, x) .≈ (Statistics.mean(x), sum(x), x))
+    @test check_inv(i_sum, (0.0, x))
+    @test i_sum(0.0, x)[1] ≈ sum(x)
+    @test check_inv(i_mean, (0.0, x))
+    @test i_mean(0.0, x)[1] ≈ mean(x)
+
     info = VarianceInfo(Float64)
     @test almost_same(i_var_mean_sum(info, copy(x))[1], VarianceInfo(Statistics.var(x), Statistics.var(x)*99, Statistics.mean(x), sum(x)))
     @test almost_same((~i_var_mean_sum)(i_var_mean_sum(info, copy(x))...), (info, x))


### PR DESCRIPTION
I don't know whether `@inbounds` and `@simd` is allowed in NiLang.

```julia
x = rand(64, 64)
@btime i_mean_sum(0.0, 0.0, $x)
# 228.673 ns (0 allocations: 0 bytes) # PR
# 3.557 μs (0 allocations: 0 bytes) # master
```

Interestingly, `i_mean_sum` is more performant than `i_mean`. Is this because the additional uncompute process is not optimized?

```julia
julia> @btime i_mean(0.0, $x);
  476.871 ns (0 allocations: 0 bytes)
```
